### PR TITLE
Search, starting decks

### DIFF
--- a/src/cljc/jinteki/fools.cljc
+++ b/src/cljc/jinteki/fools.cljc
@@ -47,7 +47,7 @@
                               :sounds    {}}
                    :bee      {:name      "Team Bee"
                               :cards     #{"Plan B" "Honeyfarm" "Chrysalis" "Hive" "Hivemind" "Swarm" "Mutate" "Interrupt 0" "Special Report"
-                                           "Bug"}
+                                           "Bug" "Chop Bot 3000"}
                               :card-icon "🐝"
                               :nickname  "buzz buzz"
                               :leader    "Bee the Change You Want to See In the World"}

--- a/src/cljs/netrunner/cardbrowser.cljs
+++ b/src/cljs/netrunner/cardbrowser.cljs
@@ -7,6 +7,7 @@
             [netrunner.account :refer [alt-art-name]]
             [netrunner.ajax :refer [GET]]
             [jinteki.cards :refer [all-cards] :as cards]
+            [jinteki.fools :as fools]
             [jinteki.decks :as decks]))
 
 (def cards-channel (chan))
@@ -271,9 +272,17 @@
     (filter-cards false :rotated cards)
     cards))
 
+(defn- all-animal-card-titles []
+  (apply clojure.set/union (map :cards (vals fools/animal-teams))))
+
 (defn filter-title [query cards]
-  (if (empty? query)
-    cards
+  (cond
+    (empty? query) cards
+
+    (= "i'm a little teapot" (.toLowerCase query))
+    (filter #(contains? (all-animal-card-titles) (:title %)) cards)
+
+    :else
     (let [lcquery (.toLowerCase query)]
       (filter #(or (not= (.indexOf (.toLowerCase (:title %)) lcquery) -1)
                    (not= (.indexOf (:normalizedtitle %) lcquery) -1))

--- a/src/cljs/netrunner/deckbuilder.cljs
+++ b/src/cljs/netrunner/deckbuilder.cljs
@@ -297,7 +297,10 @@
          (end-delete owner))))))
 
 (defn new-deck [side owner]
-  (om/set-state! owner :deck {:name "New deck" :cards [] :identity (-> side side-identities first)})
+  (om/set-state! owner :deck {:name "New deck"
+                              :username (get-in @app-state [:user :username])
+                              :cards []
+                              :identity (-> side side-identities first)})
   (try (js/ga "send" "event" "deckbuilder" "new" side) (catch js/Error e))
   (edit-deck owner))
 


### PR DESCRIPTION
In the card browser, if you search for _I'm a little teapot_ it shows all the animal cards. Because I'm tired of having to look in the file and mentally filter on types, etc.

Fixed a bug when creating a new deck where it was assuming the user was a Cat, since the `username` property was not yet set.